### PR TITLE
Avoid log polution with DeprecationWarning

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -130,7 +130,7 @@ Part.prototype = {
             else {
               stream.write("\r\n");
               callback();
-              fs.close(fd);
+              fs.close(fd, function () { }); // callback required to avoid DeprecationWarning
             }
           });
         })(); // reader()


### PR DESCRIPTION
Add a callback to `lib/multiplatform.js:133` (`fs.close(fd)`) to avoid log polution with DeprecationWarning.

This may not be the most elegant solution (ideally we would pass `callback` to the `fs.close` as second parameter) but the original logic doesn't seem to care, as it calls `callback` before closing the file - let me know if you think we should change this behaviour so I can do it in this PR.